### PR TITLE
pure-Python remove_from_zip() & zipflinger support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,25 +32,32 @@ jobs:
     - name: Cache NewPipe Build
       uses: actions/cache@v2
       with:
-        path: NewPipe/app/build/outputs/apk/release/app-release-unsigned.apk
-        key: v0.20.11
+        path: |
+          app-release-unsigned.apk
+          app-release-unsigned-zipflinger.apk
+        key: v0.21.0
     - name: Build & Test NewPipe
       run: |
         set -x
         # build APK
-        if [ -e NewPipe/app/build/outputs/apk/release/app-release-unsigned.apk ]; then
-          cd NewPipe/app/build/outputs/apk/release
-        else
-          git clone -b v0.20.11 https://github.com/TeamNewPipe/NewPipe.git
+        if [ ! -e app-release-unsigned.apk ]; then
+          git clone -b v0.21.0 https://github.com/TeamNewPipe/NewPipe.git
           cd NewPipe
-          printf '\nandroid.useNewApkCreator=false\n' >> gradle.properties
           ./gradlew assembleRelease
-          cd app/build/outputs/apk/release
+          mv app/build/outputs/apk/release/app-release-unsigned.apk \
+            ../app-release-unsigned-zipflinger.apk
+          printf '\nandroid.useNewApkCreator=false\n' >> gradle.properties
+          ./gradlew clean
+          ./gradlew assembleRelease
+          mv app/build/outputs/apk/release/app-release-unsigned.apk ../
+          cd ..
         fi
         # copy APK
         cp app-release-unsigned.apk signed.apk
         cp app-release-unsigned.apk signed-v1.apk
         cp app-release-unsigned.apk signed-jarsigner.apk
+        cp app-release-unsigned-zipflinger.apk signed-zipflinger.apk
+        cp app-release-unsigned-zipflinger.apk signed-zipflinger-v1.apk
         # generate dummy keystore & sign APKs
         apksigcopier gen-dummy ci-ks
         apksigner sign -v --ks ci-ks --ks-key-alias dummy \
@@ -60,25 +67,42 @@ jobs:
           --v2-signing-enabled=false --v3-signing-enabled=false signed-v1.apk
         PASS=dummy-password jarsigner -keystore ci-ks -storepass:env PASS \
           -sigalg SHA256withRSA -digestalg SHA-256 signed-jarsigner.apk dummy
+        apksigner sign -v --ks ci-ks --ks-key-alias dummy \
+          --ks-pass pass:dummy-password signed-zipflinger.apk
+        apksigner sign -v --ks ci-ks --ks-key-alias dummy \
+          --ks-pass pass:dummy-password \
+          --v2-signing-enabled=false --v3-signing-enabled=false signed-zipflinger-v1.apk
         # copy signatures
-        mkdir meta
+        mkdir meta meta-zipflinger
         apksigcopier extract signed.apk meta
-        ls -hlA meta
-        apksigcopier patch meta app-release-unsigned.apk patched.apk
-        apksigcopier copy signed.apk app-release-unsigned.apk copied.apk
-        apksigcopier copy --v1-only auto signed-v1.apk app-release-unsigned.apk copied-v1.apk
-        apksigcopier copy --v1-only yes signed-jarsigner.apk app-release-unsigned.apk copied-jarsigner.apk
+        apksigcopier extract signed-zipflinger.apk meta-zipflinger
+        ls -hlA meta meta-zipflinger
+        apksigcopier patch --use-zip=yes meta app-release-unsigned.apk patched.apk
+        apksigcopier patch meta app-release-unsigned.apk patched-nozip.apk
+        apksigcopier copy --use-zip=yes signed.apk app-release-unsigned.apk copied.apk
+        apksigcopier copy signed.apk app-release-unsigned.apk copied-nozip.apk
+        apksigcopier copy --use-zip=yes --v1-only=auto signed-v1.apk \
+          app-release-unsigned.apk copied-v1.apk
+        apksigcopier copy --use-zip=yes --v1-only=yes signed-jarsigner.apk \
+          app-release-unsigned.apk copied-jarsigner.apk
+        apksigcopier patch meta-zipflinger \
+          app-release-unsigned-zipflinger.apk patched-zipflinger.apk
+        apksigcopier copy signed-zipflinger.apk \
+          app-release-unsigned-zipflinger.apk copied-zipflinger.apk
+        apksigcopier copy --v1-only=auto signed-zipflinger-v1.apk \
+          app-release-unsigned-zipflinger.apk copied-zipflinger-v1.apk
         # compare APKs
         sha512sum *.apk | sort
         cmp signed.apk patched.apk
+        cmp signed.apk patched-nozip.apk
         cmp signed.apk copied.apk
+        cmp signed.apk copied-nozip.apk
         cmp signed-v1.apk copied-v1.apk
         cmp signed-jarsigner.apk copied-jarsigner.apk || true
+        cmp signed-zipflinger.apk patched-zipflinger.apk
+        cmp signed-zipflinger.apk copied-zipflinger.apk
+        cmp signed-zipflinger-v1.apk copied-zipflinger-v1.apk
         # verify APKs
-        apksigner verify -v --print-certs signed.apk
-        apksigner verify -v --print-certs signed-v1.apk
-        apksigner verify -v --print-certs signed-jarsigner.apk
-        apksigner verify -v --print-certs patched.apk
-        apksigner verify -v --print-certs copied.apk
-        apksigner verify -v --print-certs copied-v1.apk
-        apksigner verify -v --print-certs copied-jarsigner.apk
+        for apk in signed*.apk patched*.apk copied*.apk; do
+          apksigner verify -v --print-certs "$apk" | grep -v ^WARNING:
+        done

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ $ apksigcopier copy signed.apk unsigned.apk out.apk
 
 Recent versions of the Android gradle plugin will use *zipflinger* --
 which arranges the contents of the APK differently -- making
-apksigcopier fail to work.  You can tell the plugin not to use
-*zipflinger* by setting `android.useNewApkCreator=false` in
-`gradle.properties`.
+`apksigcopier` fail to work when using `--use-zip=yes` (the default is
+`no`).  You can tell the plugin not to use *zipflinger* by setting
+`android.useNewApkCreator=false` in `gradle.properties`.
 
 ## Help
 
@@ -103,12 +103,12 @@ eval (env _SHTST_COMPLETE=source_fish apksigcopier)
 
 ## Requirements
 
-* Python >= 3.5 + click + `apksigner` + `zip`.
+* Python >= 3.5 + click + `apksigner`.
 
 ### Debian/Ubuntu
 
 ```bash
-$ apt install python3-click apksigner zip
+$ apt install python3-click apksigner
 ```
 
 ## Installing

--- a/apksigcopier
+++ b/apksigcopier
@@ -21,6 +21,7 @@ import glob
 import os
 import re
 import shutil
+import struct
 import subprocess
 import tempfile
 import zipfile
@@ -53,16 +54,20 @@ class ReproducibleZipInfo(zipfile.ZipInfo):
 
     _override = {}
 
-    def __init__(self, zinfo):
+    def __init__(self, zinfo, **override):
+        if override:
+            self._override = {**self._override, **override}
         for k in self.__slots__:
             if hasattr(zinfo, k):
                 setattr(self, k, getattr(zinfo, k))
 
     def __getattribute__(self, name):
-        try:
-            return type(self)._override[name]
-        except KeyError:
-            return object.__getattribute__(self, name)
+        if name != "_override":
+            try:
+                return self._override[name]
+            except KeyError:
+                pass
+        return object.__getattribute__(self, name)
 
 
 class APKZipInfo(ReproducibleZipInfo):
@@ -92,8 +97,29 @@ def noautoyes(value):
     return {False: NO, None: AUTO, True: YES}[value]
 
 
-def remove_from_zip(zipfile, files, zip_cmd=ZIP_CMD):
-    subprocess.run([zip_cmd, "-q", "-d", zipfile] + list(files), check=True)
+# FIXME
+def remove_from_zip(zipfile, meta, zip_cmd=None):
+    if zip_cmd and shutil.which(zip_cmd):
+        files = [info.filename for info in meta]
+        subprocess.run([zip_cmd, "-q", "-d", zipfile] + list(files), check=True)
+        return
+    meta_cd_len = sum(46 + len(info.filename) for info in meta)
+    meta_offset = min(info.header_offset for info in meta)
+    data = zip_data(zipfile)
+    cd_delta = data.cd_offset - meta_offset
+    eocd_offset = data.eocd_offset - cd_delta - meta_cd_len
+    with open(zipfile, "r+b") as fh:
+        fh.seek(meta_offset)
+        fh.truncate()
+        fh.write(data.cd_and_eocd)
+        fh.seek(eocd_offset)
+        fh.truncate()
+        fh.write(data.cd_and_eocd[data.eocd_offset - data.cd_offset:])
+        fh.seek(eocd_offset + 8)
+        cd_disk, cd_tot, cd_size, cd_off = struct.unpack("<HHLL", fh.read(12))
+        fh.seek(-12, os.SEEK_CUR)
+        fh.write(struct.pack("<HHLL", cd_disk - len(meta), cd_tot - len(meta),
+                             cd_size - meta_cd_len, cd_off - cd_delta))
 
 
 def gen_dummy_key(keystore, alias="dummy", keyalg="RSA", keysize=4096,
@@ -128,22 +154,23 @@ def extract_meta(signed_apk):
                 yield info, zf_sig.read(info.filename)
 
 
-def replace_meta(extracted_meta, output_apk, zip_cmd=ZIP_CMD):
+def replace_meta(extracted_meta, output_apk, zip_cmd=None):
     """Replace v1 signature metadata in signed APK (removes v2 sig block)."""
     with zipfile.ZipFile(output_apk, "r") as zf_out:
-        meta = [info.filename for info in zf_out.infolist()
-                if is_meta(info.filename)]
+        meta = [info for info in zf_out.infolist() if is_meta(info.filename)]
+        date_time = meta[0].date_time                          # FIXME
         remove_from_zip(output_apk, meta, zip_cmd=zip_cmd)
     with zipfile.ZipFile(output_apk, "a") as zf_out:
         if "compresslevel" in zipfile.ZipFile.__doc__:         # FIXME
             for info, data in extracted_meta:
-                zf_out.writestr(APKZipInfo(info), data, compresslevel=9)
+                zf_out.writestr(APKZipInfo(info, date_time=date_time),
+                                data, compresslevel=9)
         else:
             old = zipfile._get_compressor
             zipfile._get_compressor = lambda _: zlib.compressobj(9, 8, -15)
             try:
                 for info, data in extracted_meta:
-                    zf_out.writestr(APKZipInfo(info), data)
+                    zf_out.writestr(APKZipInfo(info, date_time=date_time), data)
             finally:
                 zipfile._get_compressor = old
 
@@ -229,7 +256,7 @@ def patch_apk(extracted_meta, extracted_v2_sig, unsigned_apk,
     """Patch extracted_meta + extracted_v2_sig onto unsigned_apk and save as output_apk."""
     apksigner_cmd = config.get("apksigner_cmd", APKSIGNER_CMD)
     keytool_cmd = config.get("keytool_cmd", KEYTOOL_CMD)
-    zip_cmd = config.get("zip_cmd", ZIP_CMD)
+    zip_cmd = config.get("zip_cmd", None)
     shutil.copy(unsigned_apk, output_apk)
     if dummyks is None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -309,7 +336,16 @@ def do_copy(signed_apk, unsigned_apk, output_apk, v1_only=NO,
 def main():
     import click
 
-    V1Only = click.Choice(NOAUTOYES)
+    NAY = click.Choice(NOAUTOYES)
+
+    def zip_config(use_zip, config=None):
+        if config is None:
+            config = {}
+        if use_zip != NO:
+            config["zip_cmd"] = ZIP_CMD
+        if use_zip == YES and not shutil.which(ZIP_CMD):
+            raise click.BadOptionUsage("--use-zip", "zip command not found")
+        return config
 
     @click.group(help="""
         apksigcopier - copy/extract/patch apk signatures
@@ -321,7 +357,7 @@ def main():
     @cli.command(help="""
         Extract APK signatures from signed APK.
     """)
-    @click.option("--v1-only", type=V1Only, default=NO, show_default=True)
+    @click.option("--v1-only", type=NAY, default=NO, show_default=True)
     @click.argument("signed_apk", type=click.Path(exists=True, dir_okay=False))
     @click.argument("output_dir", type=click.Path(exists=True, file_okay=False))
     def extract(*args, **kwargs):
@@ -330,24 +366,26 @@ def main():
     @cli.command(help="""
         Patch extracted APK signatures onto unsigned APK.
     """)
-    @click.option("--v1-only", type=V1Only, default=NO, show_default=True)
     @click.option("--dummy-keystore", type=click.Path(exists=True, dir_okay=False))
+    @click.option("--use-zip", type=NAY, default=NO, show_default=True)
+    @click.option("--v1-only", type=NAY, default=NO, show_default=True)
     @click.argument("metadata_dir", type=click.Path(exists=True, file_okay=False))
     @click.argument("unsigned_apk", type=click.Path(exists=True, dir_okay=False))
     @click.argument("output_apk", type=click.Path(dir_okay=False))
-    def patch(*args, **kwargs):
-        do_patch(*args, **kwargs)
+    def patch(*args, use_zip=NO, **kwargs):
+        do_patch(*args, config=zip_config(use_zip), **kwargs)
 
     @cli.command(help="""
         Copy (extract & patch) signatures from signed to unsigned APK.
     """)
-    @click.option("--v1-only", type=V1Only, default=NO, show_default=True)
     @click.option("--dummy-keystore", type=click.Path(exists=True, dir_okay=False))
+    @click.option("--use-zip", type=NAY, default=NO, show_default=True)
+    @click.option("--v1-only", type=NAY, default=NO, show_default=True)
     @click.argument("signed_apk", type=click.Path(exists=True, dir_okay=False))
     @click.argument("unsigned_apk", type=click.Path(exists=True, dir_okay=False))
     @click.argument("output_apk", type=click.Path(dir_okay=False))
-    def copy(*args, **kwargs):
-        do_copy(*args, **kwargs)
+    def copy(*args, use_zip=NO, **kwargs):
+        do_copy(*args, config=zip_config(use_zip), **kwargs)
 
     @cli.command(help="""
         Generate dummy key(store).


### PR DESCRIPTION
More brittle than using `zip`.
Needs more testing!

cc @mimi89999  @eighthave

[NB: don't forget to update the requirements in the README & debian packaging.]