### PR TITLE
patch: exclude the JAR Signature files when copying the input APK

### DIFF
--- a/apksigcopier
+++ b/apksigcopier
@@ -173,8 +173,12 @@ def copy_apk(unsigned_apk, output_apk):
             if not APK_SIGNATURE_FILES.match(info.filename):
                 infos.append(info)
     if not allow_duplicates:
-        if len(infos) != len(set(info.filename for info in infos)):
-            raise ZipError("Duplicate ZIP entries")
+        filenames_set = set(info.filename for info in infos)
+        if len(infos) != len(filenames_set):
+            filenames = [info.filename for info in infos]
+            for f in filenames_set:
+                filenames.remove(f)
+            raise ZipError("Duplicate ZIP entries: " + ' '.join(filenames))
     zdata = zip_data(unsigned_apk)
     offsets = {}
     with open(unsigned_apk, "rb") as fhi, open(output_apk, "w+b") as fho:

--- a/apksigcopier
+++ b/apksigcopier
@@ -37,6 +37,7 @@ NAME = "apksigcopier"
 SIGBLOCK, SIGOFFSET = "APKSigningBlock", "APKSigningBlockOffset"
 NOAUTOYES = NO, AUTO, YES = ("no", "auto", "yes")
 APK_META = re.compile(r"^META-INF/([0-9A-Za-z_-]+\.(SF|RSA|DSA|EC)|MANIFEST\.MF)$")
+APK_SIGNATURE_FILES = re.compile(r'META-INF/[0-9A-Za-z_\-]+\.(SF|RSA|DSA|EC)')
 META_EXT = ("SF", "RSA|DSA|EC", "MF")
 COPY_EXCLUDE = ("META-INF/MANIFEST.MF",)
 DATETIMEZERO = (1980, 0, 0, 0, 0, 0)
@@ -166,8 +167,11 @@ def copy_apk(unsigned_apk, output_apk):
 
     Returns max date_time.
     """
+    infos = []
     with zipfile.ZipFile(unsigned_apk, "r") as zf:
-        infos = zf.infolist()
+        for info in zf.infolist():
+            if not APK_SIGNATURE_FILES.match(info.filename):
+                infos.append(info)
     if not allow_duplicates:
         if len(infos) != len(set(info.filename for info in infos)):
             raise ZipError("Duplicate ZIP entries")


### PR DESCRIPTION
When running `apksigcopier patch`, if there are JAR Signature files in the source APK, e.g. the "unsigned" APK, they should be ignored.  They will never be useful there, and by not copying them, it makes _apksigcopier_ more tolerant of the inputs #35 

I threw in an extended error message while I was at it.